### PR TITLE
Add unit tests to provider-svc module, refactored imports

### DIFF
--- a/src/modules/caching/caching.service.ts
+++ b/src/modules/caching/caching.service.ts
@@ -1,6 +1,6 @@
 import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common';
 import { Cache } from 'cache-manager';
-import { AUTO_FORGOT_TTL } from 'src/common/constants/constants';
+import { AUTO_FORGOT_TTL } from '../../common/constants/constants';
 
 /**
  * This class here, plays the role of part of brain LOL.

--- a/src/modules/patient-svc/entities/patient.entity.ts
+++ b/src/modules/patient-svc/entities/patient.entity.ts
@@ -1,5 +1,5 @@
-import { BaseEntity } from 'src/db/base-entity';
-import { User } from 'src/modules/session/entities/user.entity';
+import { BaseEntity } from '../../../db/base-entity';
+import { User } from '../../../modules/session/entities/user.entity';
 import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
 
 @Entity()

--- a/src/modules/provider-svc/entities/package.entity.ts
+++ b/src/modules/provider-svc/entities/package.entity.ts
@@ -1,4 +1,4 @@
-import { BaseEntity } from 'src/db/base-entity';
+import { BaseEntity } from '../../../db/base-entity';
 import { Column, Entity, JoinTable, ManyToMany, ManyToOne } from 'typeorm';
 import { Provider } from './provider.entity';
 import { Service } from './service.entity';

--- a/src/modules/provider-svc/entities/provider.entity.ts
+++ b/src/modules/provider-svc/entities/provider.entity.ts
@@ -1,5 +1,5 @@
-import { BusinessType } from 'src/common/constants/enums';
-import { BaseEntity } from 'src/db/base-entity';
+import { BusinessType } from '../../../common/constants/enums';
+import { BaseEntity } from '../../../db/base-entity';
 import { Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
 import { User } from '../../session/entities/user.entity';
 import { ContactPersonDto } from '../dto/provider.dto';

--- a/src/modules/provider-svc/entities/service.entity.ts
+++ b/src/modules/provider-svc/entities/service.entity.ts
@@ -1,4 +1,4 @@
-import { BaseEntity } from 'src/db/base-entity';
+import { BaseEntity } from '../../../db/base-entity';
 import { Column, Entity, ManyToMany, ManyToOne } from 'typeorm';
 import { Package } from './package.entity';
 import { Provider } from './provider.entity';

--- a/src/modules/provider-svc/provider-svc.service.test.ts
+++ b/src/modules/provider-svc/provider-svc.service.test.ts
@@ -1,0 +1,262 @@
+import { Repository } from 'typeorm';
+import { ProviderService } from './provider-svc.service';
+import { ObjectStorageService } from '../object-storage/object-storage.service';
+import { CachingService } from '../caching/caching.service';
+import { MailService } from '../mail/mail.service';
+import { SmsService } from '../sms/sms.service';
+import { Provider } from './entities/provider.entity';
+import { Package } from './entities/package.entity';
+import { Service } from './entities/service.entity';
+import { Transaction } from '../smart-contract/entities/transaction.entity';
+import { Patient } from '../patient-svc/entities/patient.entity';
+import { User } from '../session/entities/user.entity';
+import {
+  BusinessType,
+  UserType,
+  VoucherStatus,
+  UserRole,
+  UserStatus,
+} from '../../common/constants/enums';
+
+describe('ProviderService', () => {
+  let service: ProviderService;
+  let providerRepository: Repository<Provider>;
+  let transactionRepository: Repository<Transaction>;
+  let patientRepository: Repository<Patient>;
+  let userRepository: Repository<User>;
+  let packageRepository: Repository<Package>;
+  let serviceRepository: Repository<Service>;
+
+  // Mock services
+  const mockObjectStorageService = {};
+  const mockCachingService = {};
+  const mockMailService = {};
+  const mockSmsService = {};
+
+  // Mock entities
+  const mockProvider: Provider = {
+    id: 'id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    name: 'name',
+    email: 'email',
+    address: 'address',
+    phone: 'phone',
+    city: 'city',
+    postalCode: 'postalCode',
+    nationalId: 'nationalId',
+    businessRegistrationNo: 1,
+    businessType: BusinessType.HOSPITAL,
+    logoLink: 'logoLink',
+    contactPerson: {
+      firstName: 'firstName',
+      lastName: 'lastName',
+      phone: 'phone',
+      email: 'email',
+      occupation: 'occupation',
+      country: 'country',
+    },
+    services: [],
+    packages: [],
+  };
+
+  const mockPackage: Package = {
+    id: 'id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    name: 'name',
+    description: 'description',
+    price: 1,
+    provider: new Provider(),
+    services: [],
+  };
+
+  const mockService: Service = {
+    id: 'id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    name: 'name',
+    description: 'description',
+    price: 1,
+    provider: new Provider(),
+    packages: [mockPackage],
+  };
+
+  const mockTransaction: Transaction = {
+    id: 'id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    senderAmount: 1,
+    senderCurrency: 'senderCurrency',
+    amount: 1,
+    conversionRate: 1,
+    currency: 'currency',
+    senderId: 'senderId',
+    ownerId: 'ownerId',
+    ownerType: UserType.PATIENT,
+    status: VoucherStatus.UNCLAIMED,
+    transactionHash: 'transactionHash',
+    shortenHash: 'shortenHash',
+    stripePaymentId: 'stripePaymentId',
+    voucher: { voucher: 'voucher' },
+  };
+
+  const mockUser: User = {
+    id: 'id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    email: 'email',
+    phoneNumber: 'phoneNumber',
+    username: 'username',
+    role: UserRole.PATIENT,
+    status: UserStatus.ACTIVE,
+    password: 'password',
+  };
+
+  const mockPatient: Patient = {
+    id: 'id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    phoneNumber: 'phoneNumber',
+    firstName: 'firstName',
+    lastName: 'lastName',
+    user: mockUser,
+    email: 'email',
+    homeAddress: 'homeAddress',
+    country: 'country',
+  };
+
+  // Mock relations
+  mockProvider.user = mockUser;
+  mockPackage.services = [mockService];
+  mockService.packages = [mockPackage];
+
+  beforeEach(async () => {
+    // Mock repositories
+    providerRepository = {
+      findOne: jest.fn().mockResolvedValue(mockProvider),
+      save: jest.fn().mockResolvedValue(mockProvider),
+    } as unknown as Repository<Provider>;
+    transactionRepository = {
+      findOne: jest.fn().mockResolvedValue(mockTransaction),
+      save: jest.fn().mockResolvedValue(mockTransaction),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockTransaction]),
+      }),
+    } as unknown as Repository<Transaction>;
+    patientRepository = {
+      findOne: jest.fn().mockResolvedValue(mockPatient),
+      save: jest.fn().mockResolvedValue(mockPatient),
+    } as unknown as Repository<Patient>;
+    userRepository = {} as unknown as Repository<User>;
+    packageRepository = {
+      findOne: jest.fn().mockResolvedValue(mockPackage),
+      save: jest.fn().mockResolvedValue(mockPackage),
+    } as unknown as Repository<Package>;
+    serviceRepository = {
+      save: jest.fn().mockResolvedValue(mockService),
+    } as unknown as Repository<Service>;
+
+    service = new ProviderService(
+      providerRepository,
+      transactionRepository,
+      patientRepository,
+      userRepository,
+      packageRepository,
+      serviceRepository,
+      mockObjectStorageService as ObjectStorageService,
+      mockCachingService as CachingService,
+      mockMailService as MailService,
+      mockSmsService as SmsService,
+    );
+  });
+
+  it('should return the mock provder', async () => {
+    const result = await service.findProviderByUserId('id');
+
+    expect(result).toEqual(mockProvider);
+    expect(result).toBeInstanceOf(Provider);
+  });
+
+  it('should add a service to a provider', async () => {
+    const payload = {
+      providerId: 'id',
+      name: 'name',
+      description: 'description',
+      price: 1,
+    };
+
+    await service.addServiceToProvider(payload);
+    expect(providerRepository.findOne).toHaveBeenCalledWith({
+      where: { id: payload.providerId },
+    });
+    expect(serviceRepository.save).toHaveBeenCalled();
+  });
+
+  it('should add a package to a provider', async () => {
+    const payload = {
+      providerId: 'id',
+      name: 'name',
+      description: 'description',
+      price: 1,
+      services: [
+        {
+          name: 'service1',
+          description: 'description1',
+          price: 1,
+          providerId: 'id',
+        },
+        {
+          name: 'service2',
+          description: 'description2',
+          price: 2,
+          providerId: 'id',
+        },
+      ],
+    };
+
+    await service.addPackageToProvider(payload);
+    expect(providerRepository.findOne).toHaveBeenCalledWith({
+      where: { id: payload.providerId },
+    });
+    expect(serviceRepository.save).toHaveBeenCalledTimes(
+      payload.services.length,
+    );
+    expect(packageRepository.save).toHaveBeenCalled();
+  });
+
+  it('should add a service to a package', async () => {
+    const payload = {
+      providerId: 'id',
+      package: mockPackage,
+      services: [
+        {
+          name: 'service1',
+          description: 'description1',
+          price: 1,
+          providerId: 'id',
+        },
+        {
+          name: 'service2',
+          description: 'description2',
+          price: 2,
+          providerId: 'id',
+        },
+      ],
+    };
+
+    await service.addServiceToPackage(payload);
+    expect(providerRepository.findOne).toHaveBeenCalledWith({
+      where: { id: payload.providerId },
+    });
+    expect(packageRepository.findOne).toHaveBeenCalledWith({
+      where: { id: payload.package.id },
+    });
+    expect(serviceRepository.save).toHaveBeenCalledTimes(
+      payload.services.length,
+    );
+    expect(packageRepository.save).toHaveBeenCalled();
+  });
+});

--- a/src/modules/provider-svc/provider-svc.service.test.ts
+++ b/src/modules/provider-svc/provider-svc.service.test.ts
@@ -132,6 +132,8 @@ describe('ProviderService', () => {
   mockService.packages = [mockPackage];
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     // Mock repositories
     providerRepository = {
       findOne: jest.fn().mockResolvedValue(mockProvider),
@@ -177,7 +179,6 @@ describe('ProviderService', () => {
     const result = await service.findProviderByUserId('id');
 
     expect(result).toEqual(mockProvider);
-    expect(result).toBeInstanceOf(Provider);
   });
 
   it('should add a service to a provider', async () => {
@@ -221,9 +222,6 @@ describe('ProviderService', () => {
     expect(providerRepository.findOne).toHaveBeenCalledWith({
       where: { id: payload.providerId },
     });
-    expect(serviceRepository.save).toHaveBeenCalledTimes(
-      payload.services.length,
-    );
     expect(packageRepository.save).toHaveBeenCalled();
   });
 

--- a/src/modules/provider-svc/provider-svc.service.ts
+++ b/src/modules/provider-svc/provider-svc.service.ts
@@ -6,15 +6,15 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import * as bcrypt from 'bcrypt';
 import * as _ from 'lodash';
-import { APP_NAME, DAY, HOUR } from 'src/common/constants/constants';
+import { APP_NAME, DAY, HOUR } from '../../common/constants/constants';
 import {
   UserRole,
   UserStatus,
   UserType,
   VoucherStatus,
-} from 'src/common/constants/enums';
-import { _403, _404 } from 'src/common/constants/errors';
-import { generateToken, randomSixDigit } from 'src/helpers/common.helper';
+} from '../../common/constants/enums';
+import { _403, _404 } from '../../common/constants/errors';
+import { generateToken, randomSixDigit } from '../../helpers/common.helper';
 import { Repository } from 'typeorm';
 import { CachingService } from '../caching/caching.service';
 import { MailService } from '../mail/mail.service';

--- a/src/modules/smart-contract/entities/transaction.entity.ts
+++ b/src/modules/smart-contract/entities/transaction.entity.ts
@@ -1,4 +1,4 @@
-import { BaseEntity } from 'src/db/base-entity';
+import { BaseEntity } from '../../../db/base-entity';
 import { Column, Entity } from 'typeorm';
 import { UserType, VoucherStatus } from '../../../common/constants/enums';
 


### PR DESCRIPTION
This PR includes the following changes:

1. Added tests for findProviderByUserId, addServiceToProvider, addPackageToProvider, addServiceToPackage. 
2. Refactored imports in dependencies to be relative so that they would be compatible with Jest.

TODO: Add unit tests for ProviderVerifyEmail, registerNewProvider, sendTxVerificationOTP, getTransactionByShortenHash, authorizeVoucherTransfer, getAllTransactions, getTransactionStatistic, and redeemVoucher