### PR TITLE
feature: add route to retrieve services of provider

### DIFF
--- a/src/modules/provider-svc/provider-svc.controller.ts
+++ b/src/modules/provider-svc/provider-svc.controller.ts
@@ -26,6 +26,7 @@ import {
   SearchTransactionDto,
 } from './dto/provider.dto';
 import { ProviderService } from './provider-svc.service';
+import { Service } from './entities/service.entity';
 
 @ApiTags('Provider')
 @Controller('provider')
@@ -140,6 +141,15 @@ export class ProviderController {
   ): Promise<void> {
     serviceDto.providerId = providerId;
     return this.providerService.addServiceToProvider(serviceDto);
+  }
+
+  @Get(':providerId/service')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'API endpoint to retrieve services of Provider' })
+  getServicesByProviderId(
+    @Param('providerId') providerId: string,
+  ): Promise<Service[]> {
+    return this.providerService.getServicesByProviderId(providerId);
   }
 
   @Post(':providerId/package')

--- a/src/modules/provider-svc/provider-svc.service.ts
+++ b/src/modules/provider-svc/provider-svc.service.ts
@@ -371,6 +371,21 @@ export class ProviderService {
     service = await this.servicesRepository.save(service);
   }
 
+  // Get services of provider
+  async getServicesByProviderId(providerId: string): Promise<Service[]> {
+    const provider = await this.providerRepository.findOne({
+      where: { id: providerId },
+    });
+
+    if (!provider) throw new ForbiddenException(_404.PROVIDER_NOT_FOUND);
+
+    const services = await this.servicesRepository.find({
+      where: { provider },
+    });
+
+    return services;
+  }
+
   // Add package to provider
   async addPackageToProvider(payload: CreatePackageDto): Promise<void> {
     const provider = await this.providerRepository.findOne({


### PR DESCRIPTION
Changes included in this PR:

1. Added `getServicesByProviderId` method to `provider-svc.service.ts` that retrieves all services of a particular Provider.
2. Added `@Get(':providerId/service')` route to `provider-svc.controller.ts` that invokes `getServicesByProviderId`.

Please review and give any feedback, thanks!