### PR TITLE
test: provider SVC

### DIFF
--- a/src/modules/provider-svc/provider-svc.service.test.ts
+++ b/src/modules/provider-svc/provider-svc.service.test.ts
@@ -514,6 +514,43 @@ describe('ProviderService', () => {
     });
   });
 
+  describe('redeemVoucher', () => {
+    const hashes = ['hash1', 'hash2'];
+    const mockTx1 = {
+      ...mockTransaction,
+      transactionHash: 'hash1',
+    };
+    const mockTx2 = {
+      ...mockTransaction,
+      transactionHash: 'hash2',
+    };
+
+    const newTxList = [
+      {
+        ...mockTx1,
+        status: VoucherStatus.PENDING,
+      },
+      {
+        ...mockTx2,
+        status: VoucherStatus.PENDING,
+      },
+    ];
+
+    it('should redeem vouchers', async () => {
+      transactionRepository.createQueryBuilder = jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([mockTx1, mockTx2]),
+      });
+
+      transactionRepository.save = jest.fn().mockResolvedValue(newTxList);
+
+      const result = await service.redeemVoucher(hashes);
+      expect(transactionRepository.save).toHaveBeenCalledWith(newTxList);
+      expect(result).toEqual(newTxList);
+    });
+  });
+
   describe('addServiceToProvider', () => {
     const payload = {
       providerId: 'id',

--- a/src/modules/provider-svc/provider-svc.service.test.ts
+++ b/src/modules/provider-svc/provider-svc.service.test.ts
@@ -175,6 +175,7 @@ describe('ProviderService', () => {
     } as unknown as Repository<Package>;
     serviceRepository = {
       save: jest.fn().mockResolvedValue(mockService),
+      find: jest.fn().mockResolvedValue([mockService]),
     } as unknown as Repository<Service>;
 
     service = new ProviderService(
@@ -571,6 +572,24 @@ describe('ProviderService', () => {
       providerRepository.findOne = jest.fn().mockResolvedValue(null);
 
       await expect(service.addServiceToProvider(payload)).rejects.toThrow(
+        new ForbiddenException(_404.PROVIDER_NOT_FOUND),
+      );
+    });
+  });
+
+  describe('getServicesByProviderId', () => {
+    it('should return all services of a provider', async () => {
+      const result = await service.getServicesByProviderId('id');
+      expect(serviceRepository.find).toHaveBeenCalledWith({
+        where: { provider: mockProvider },
+      });
+      expect(result).toEqual([mockService]);
+    });
+
+    it('should throw an error if the provider does not exist', async () => {
+      providerRepository.findOne = jest.fn().mockResolvedValue(null);
+
+      await expect(service.getServicesByProviderId('someId')).rejects.toThrow(
         new ForbiddenException(_404.PROVIDER_NOT_FOUND),
       );
     });

--- a/src/modules/provider-svc/provider-svc.service.test.ts
+++ b/src/modules/provider-svc/provider-svc.service.test.ts
@@ -444,6 +444,23 @@ describe('ProviderService', () => {
     });
   });
 
+  describe('getAllTransactions', () => {
+    const providerId = 'id';
+
+    it('should return all transactions', async () => {
+      const result = await service.getAllTransactions(providerId);
+      expect(transactionRepository.createQueryBuilder).toHaveBeenCalledWith(
+        'transaction',
+      );
+      expect(
+        transactionRepository.createQueryBuilder().where,
+      ).toHaveBeenCalledWith('transaction.ownerType = :ownerType', {
+        providerId,
+      });
+      expect(result).toEqual([mockTransaction]);
+    });
+  });
+
   describe('addServiceToProvider', () => {
     const payload = {
       providerId: 'id',

--- a/src/modules/provider-svc/provider-svc.service.ts
+++ b/src/modules/provider-svc/provider-svc.service.ts
@@ -306,7 +306,6 @@ export class ProviderService {
       .where('transaction.ownerId = :providerId', { providerId })
       .getMany();
 
-    console.log(transactions);
     let totalRedeemedAmount = 0,
       totalPendingAmount = 0,
       totalUnclaimedAmount = 0;

--- a/src/modules/provider-svc/provider-svc.service.ts
+++ b/src/modules/provider-svc/provider-svc.service.ts
@@ -306,6 +306,7 @@ export class ProviderService {
       .where('transaction.ownerId = :providerId', { providerId })
       .getMany();
 
+    console.log(transactions);
     let totalRedeemedAmount = 0,
       totalPendingAmount = 0,
       totalUnclaimedAmount = 0;


### PR DESCRIPTION
# Improved Code Coverage for `provider-svc.service.ts`

## Summary

This PR extends the existing test suite for the `provider-svc.service.ts` file to include all methods contained in the `ProviderService` class. This addresses the provider-svc tests task included in Issue #50.

## Changes

Created tests for the following methods:
- `providerVerifyEmail`
- `registerNewProvider`
- `sendTxVerificationOTP`
- `getTransactionByShortenHash`
- `authorizeVoucherTransfer`
- `getAllTransactions`
- `getTransactionStatistic`
- `redeemVoucher`
- `getServicesByProviderId`

Extended existing tests for the following methods:
- `findProviderByUserId`
- `addServiceToProvider`
- `addPackageToProvider`
- `addServiceToiPackage`

Also cleaned up the test suite for improved readability and ease of extension.

## Impact

The improvements in testing have brought the code coverage for `provider-svc.service.ts` to:

- 100% statement coverage
- 83% branch coverage

This improves upon the previous tests included in  [PR #42](https://github.com/WiiQare/backend/pull/42).

## Request for Review

I would appreciate any feedback on the tests included and any improvements that should be made. Thanks!
