### PR TITLE
test: smart-contract and its transaction service

### DIFF
--- a/src/modules/smart-contract/smart-contract.providers.ts
+++ b/src/modules/smart-contract/smart-contract.providers.ts
@@ -1,5 +1,5 @@
 import { Provider } from '@nestjs/common';
-import { AppConfigService } from 'src/config/app-config.service';
+import { AppConfigService } from '../../config/app-config.service';
 import Web3 from 'web3';
 
 export const nodeProvider: Provider = {

--- a/src/modules/smart-contract/smart-contract.service.test.ts
+++ b/src/modules/smart-contract/smart-contract.service.test.ts
@@ -74,6 +74,30 @@ describe('SmartContractService', () => {
             }),
           };
         }),
+        getAllVouchers: jest.fn().mockImplementation(() => {
+          return {
+            call: jest.fn().mockResolvedValue([
+              {
+                owner: '0x123',
+                patient: '0x456',
+                amount: 1,
+                currency: 'USD',
+                status: 1,
+                createdAt: 1234567890,
+                updatedAt: 1234567890,
+              },
+              {
+                owner: '0x123',
+                patient: '0x456',
+                amount: 1,
+                currency: 'USD',
+                status: 1,
+                createdAt: 1234567890,
+                updatedAt: 1234567890,
+              },
+            ]),
+          };
+        }),
       },
     }));
 

--- a/src/modules/smart-contract/smart-contract.service.test.ts
+++ b/src/modules/smart-contract/smart-contract.service.test.ts
@@ -1,0 +1,39 @@
+import { Test } from '@nestjs/testing';
+import { Account } from 'web3-core';
+import { Contract } from 'web3-eth-contract';
+import Web3 from 'web3';
+import { AppConfigService } from '../../config/app-config.service';
+import { AbiItem } from 'web3-utils';
+
+import abi from './abi/abi.json';
+
+import { SmartContractService } from './smart-contract.service';
+import { TransactionService } from './transaction.service';
+
+describe('SmartContractService', () => {
+  let smartContractService: SmartContractService;
+  let transactionService: TransactionService;
+  let appConfigService: AppConfigService;
+  let web3: Web3;
+  let mockWiiqareContract: Contract;
+  let mockWiiQareAccount: Account;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        SmartContractService,
+        TransactionService,
+        AppConfigService,
+        { provide: 'WEB3', useValue: web3 },
+      ],
+    }).compile();
+    smartContractService =
+      moduleRef.get<SmartContractService>(SmartContractService);
+    transactionService = moduleRef.get<TransactionService>(TransactionService);
+    appConfigService = moduleRef.get<AppConfigService>(AppConfigService);
+
+    web3 = moduleRef.get<Web3>('WEB3');
+    mockWiiqareContract = {} as Contract;
+    mockWiiQareAccount = {} as Account;
+  });
+});

--- a/src/modules/smart-contract/smart-contract.service.test.ts
+++ b/src/modules/smart-contract/smart-contract.service.test.ts
@@ -2,7 +2,8 @@ import { SmartContractService } from './smart-contract.service';
 import { AppConfigService } from '../../config/app-config.service';
 import Web3 from 'web3';
 import { MintVoucherDto } from './dto/mint-voucher.dto';
-import { VoucherStatus } from '../../common/constants/enums';
+import * as helpers from '../../helpers/common.helper';
+
 describe('SmartContractService', () => {
   // Mock services
   const mockAppConfigService = {
@@ -19,6 +20,17 @@ describe('SmartContractService', () => {
           mintVoucher: jest.fn().mockReturnValue({
             send: jest.fn().mockResolvedValue({
               transactionHash: '0x123',
+            }),
+          }),
+          vouchers: jest.fn().mockReturnValue({
+            call: jest.fn().mockResolvedValue({
+              owner: '0x123',
+              patient: '0x456',
+              amount: 1,
+              currency: 'USD',
+              status: 1,
+              createdAt: 1234567890,
+              updatedAt: 1234567890,
             }),
           }),
         },
@@ -70,14 +82,14 @@ describe('SmartContractService', () => {
   });
 
   describe('mintVoucher', () => {
-    it('should mint a voucher', async () => {
-      const mintVoucherDto: MintVoucherDto = {
-        amount: 1,
-        currency: 'USD',
-        ownerId: '0x123',
-        patientId: '0x456',
-      };
+    const mintVoucherDto: MintVoucherDto = {
+      amount: 1,
+      currency: 'USD',
+      ownerId: '0x123',
+      patientId: '0x456',
+    };
 
+    it('should mint a voucher', async () => {
       const gasFees = { gasPrice: 1, safeLow: 1, standard: 1, fast: 1 };
 
       smartContractService.getGasFees = jest.fn().mockResolvedValue(gasFees);
@@ -88,6 +100,72 @@ describe('SmartContractService', () => {
       expect(response).toEqual({
         transactionHash: '0x123',
       });
+    });
+
+    it('should throw an error if the contract method throws an error', async () => {
+      mockWeb3.eth.Contract = jest.fn().mockImplementation(() => {
+        return {
+          methods: {
+            mintVoucher: jest.fn().mockReturnValue({
+              send: jest.fn().mockRejectedValue(new Error('Contract Error')),
+            }),
+          },
+        };
+      });
+
+      smartContractService = new SmartContractService(
+        mockAppConfigService,
+        mockWeb3,
+      );
+
+      const logErrorSpy = jest.spyOn(helpers, 'logError');
+
+      await smartContractService.mintVoucher(mintVoucherDto);
+
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        'Error in mintVoucher: Error: Contract Error',
+      );
+
+      logErrorSpy.mockRestore();
+    });
+  });
+
+  describe('getVoucherById', () => {
+    const voucherId = 'someVoucherId';
+
+    it('should return voucher information', async () => {
+      // The implementation of this method is still in progress, so this
+      // test is just a placeholder for now.
+      await smartContractService.getVoucherById(voucherId);
+
+      expect(mockWeb3.eth.Contract).toBeCalledTimes(1);
+    });
+
+    it('should throw an error if the contract method throws an error', async () => {
+      mockWeb3.eth.Contract = jest.fn().mockImplementation(() => {
+        return {
+          methods: {
+            vouchers: jest.fn().mockReturnValue({
+              call: jest.fn().mockRejectedValue(new Error('Contract Error')),
+            }),
+          },
+        };
+      });
+
+      smartContractService = new SmartContractService(
+        mockAppConfigService,
+        mockWeb3,
+      );
+
+      const logErrorSpy = jest.spyOn(helpers, 'logError');
+
+      await smartContractService.getVoucherById(voucherId);
+
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        'Error in getVoucher: Error: Contract Error',
+      );
+
+      logErrorSpy.mockRestore();
     });
   });
 });

--- a/src/modules/smart-contract/smart-contract.service.test.ts
+++ b/src/modules/smart-contract/smart-contract.service.test.ts
@@ -1,39 +1,74 @@
-import { Test } from '@nestjs/testing';
-import { Account } from 'web3-core';
-import { Contract } from 'web3-eth-contract';
-import Web3 from 'web3';
-import { AppConfigService } from '../../config/app-config.service';
-import { AbiItem } from 'web3-utils';
-
-import abi from './abi/abi.json';
-
+import { Test, TestingModule } from '@nestjs/testing';
 import { SmartContractService } from './smart-contract.service';
 import { TransactionService } from './transaction.service';
+import { nodeProvider } from './smart-contract.providers';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Transaction } from './entities/transaction.entity';
+import { AppConfigService } from '../../config/app-config.service';
+import Web3 from 'web3';
+import { Contract } from 'web3-eth-contract';
+import { Account } from 'web3-core';
 
 describe('SmartContractService', () => {
   let smartContractService: SmartContractService;
   let transactionService: TransactionService;
   let appConfigService: AppConfigService;
-  let web3: Web3;
+  let web3Mock: Web3;
   let mockWiiqareContract: Contract;
   let mockWiiQareAccount: Account;
 
   beforeEach(async () => {
-    const moduleRef = await Test.createTestingModule({
+    const nodeProviderMock = {
+      provide: 'WEB3',
+      useFactory: () => {
+        return {
+          eth: {
+            getGasPrice: jest.fn(),
+            Contract: jest.fn(),
+            accounts: {
+              privateKeyToAccount: jest.fn().mockReturnValue({}),
+            },
+          },
+        };
+      },
+    } as unknown as typeof nodeProvider;
+
+    const moduleRef: TestingModule = await Test.createTestingModule({
       providers: [
         SmartContractService,
         TransactionService,
-        AppConfigService,
-        { provide: 'WEB3', useValue: web3 },
+        {
+          provide: AppConfigService,
+          useValue: {},
+        },
+        nodeProviderMock,
+        {
+          provide: getRepositoryToken(Transaction),
+          useValue: {},
+        },
       ],
     }).compile();
+
     smartContractService =
       moduleRef.get<SmartContractService>(SmartContractService);
     transactionService = moduleRef.get<TransactionService>(TransactionService);
     appConfigService = moduleRef.get<AppConfigService>(AppConfigService);
 
-    web3 = moduleRef.get<Web3>('WEB3');
     mockWiiqareContract = {} as Contract;
     mockWiiQareAccount = {} as Account;
+  });
+
+  describe('getGasFees', () => {
+    it('should return gas fees', async () => {
+      const gasFees = { gasPrice: 1, safeLow: 1, standard: 1, fast: 1 };
+      jest.spyOn(global, 'fetch').mockImplementation(
+        () =>
+          Promise.resolve({
+            json: () => Promise.resolve(gasFees),
+          }) as any,
+      );
+      const result = await smartContractService.getGasFees();
+      expect(result).toEqual(gasFees);
+    });
   });
 });

--- a/src/modules/smart-contract/smart-contract.service.test.ts
+++ b/src/modules/smart-contract/smart-contract.service.test.ts
@@ -191,4 +191,59 @@ describe('SmartContractService', () => {
       logErrorSpy.mockRestore();
     });
   });
+
+  describe('getAllVouchers', () => {
+    it('should return all vouchers', async () => {
+      const response = await smartContractService.getAllVouchers('0x123');
+
+      expect(mockWeb3.eth.Contract).toBeCalledTimes(1);
+      expect(response).toEqual([
+        {
+          owner: '0x123',
+          patient: '0x456',
+          amount: 1,
+          currency: 'USD',
+          status: 1,
+          createdAt: 1234567890,
+          updatedAt: 1234567890,
+        },
+        {
+          owner: '0x123',
+          patient: '0x456',
+          amount: 1,
+          currency: 'USD',
+          status: 1,
+          createdAt: 1234567890,
+          updatedAt: 1234567890,
+        },
+      ]);
+    });
+
+    it('should throw an error if the contract method throws an error', async () => {
+      mockWeb3.eth.Contract = jest.fn().mockImplementation(() => {
+        return {
+          methods: {
+            getAllVouchers: jest.fn().mockReturnValue({
+              call: jest.fn().mockRejectedValue(new Error('Contract Error')),
+            }),
+          },
+        };
+      });
+
+      smartContractService = new SmartContractService(
+        mockAppConfigService,
+        mockWeb3,
+      );
+
+      const logErrorSpy = jest.spyOn(helpers, 'logError');
+
+      await smartContractService.getAllVouchers('0x123');
+
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        'Error in getVoucher: Error: Contract Error',
+      );
+
+      logErrorSpy.mockRestore();
+    });
+  });
 });

--- a/src/modules/smart-contract/smart-contract.service.test.ts
+++ b/src/modules/smart-contract/smart-contract.service.test.ts
@@ -1,61 +1,58 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { SmartContractService } from './smart-contract.service';
-import { TransactionService } from './transaction.service';
-import { nodeProvider } from './smart-contract.providers';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { Transaction } from './entities/transaction.entity';
 import { AppConfigService } from '../../config/app-config.service';
 import Web3 from 'web3';
-import { Contract } from 'web3-eth-contract';
-import { Account } from 'web3-core';
-
+import { MintVoucherDto } from './dto/mint-voucher.dto';
+import { VoucherStatus } from '../../common/constants/enums';
 describe('SmartContractService', () => {
+  // Mock services
+  const mockAppConfigService = {
+    smartContractPrivateKey:
+      '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    smartContractAddress: '0xabcdef0123456789abcdef0123456789abcdef01234567',
+  } as unknown as AppConfigService;
+
+  const mockWeb3 = {
+    eth: {
+      getGasPrice: jest.fn(),
+      Contract: jest.fn().mockReturnValue({
+        methods: {
+          mintVoucher: jest.fn().mockReturnValue({
+            send: jest.fn().mockResolvedValue({
+              transactionHash: '0x123',
+            }),
+          }),
+        },
+      }),
+      accounts: {
+        privateKeyToAccount: jest.fn().mockReturnValue({
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+        }),
+        wallet: {
+          add: jest.fn(),
+        },
+      },
+    },
+    Contract: jest.fn().mockReturnValue({
+      methods: {
+        mintVoucher: jest.fn().mockReturnValue({
+          send: jest.fn().mockResolvedValue({
+            transactionHash: '0x123',
+          }),
+        }),
+      },
+    }),
+  } as unknown as Web3;
+
   let smartContractService: SmartContractService;
-  let transactionService: TransactionService;
-  let appConfigService: AppConfigService;
-  let web3Mock: Web3;
-  let mockWiiqareContract: Contract;
-  let mockWiiQareAccount: Account;
 
   beforeEach(async () => {
-    const nodeProviderMock = {
-      provide: 'WEB3',
-      useFactory: () => {
-        return {
-          eth: {
-            getGasPrice: jest.fn(),
-            Contract: jest.fn(),
-            accounts: {
-              privateKeyToAccount: jest.fn().mockReturnValue({}),
-            },
-          },
-        };
-      },
-    } as unknown as typeof nodeProvider;
+    jest.clearAllMocks();
 
-    const moduleRef: TestingModule = await Test.createTestingModule({
-      providers: [
-        SmartContractService,
-        TransactionService,
-        {
-          provide: AppConfigService,
-          useValue: {},
-        },
-        nodeProviderMock,
-        {
-          provide: getRepositoryToken(Transaction),
-          useValue: {},
-        },
-      ],
-    }).compile();
-
-    smartContractService =
-      moduleRef.get<SmartContractService>(SmartContractService);
-    transactionService = moduleRef.get<TransactionService>(TransactionService);
-    appConfigService = moduleRef.get<AppConfigService>(AppConfigService);
-
-    mockWiiqareContract = {} as Contract;
-    mockWiiQareAccount = {} as Account;
+    // Initialize smartContractService
+    smartContractService = new SmartContractService(
+      mockAppConfigService,
+      mockWeb3,
+    );
   });
 
   describe('getGasFees', () => {
@@ -69,6 +66,28 @@ describe('SmartContractService', () => {
       );
       const result = await smartContractService.getGasFees();
       expect(result).toEqual(gasFees);
+    });
+  });
+
+  describe('mintVoucher', () => {
+    it('should mint a voucher', async () => {
+      const mintVoucherDto: MintVoucherDto = {
+        amount: 1,
+        currency: 'USD',
+        ownerId: '0x123',
+        patientId: '0x456',
+      };
+
+      const gasFees = { gasPrice: 1, safeLow: 1, standard: 1, fast: 1 };
+
+      smartContractService.getGasFees = jest.fn().mockResolvedValue(gasFees);
+
+      const response = await smartContractService.mintVoucher(mintVoucherDto);
+
+      expect(smartContractService.getGasFees).toBeCalledTimes(1);
+      expect(response).toEqual({
+        transactionHash: '0x123',
+      });
     });
   });
 });

--- a/src/modules/smart-contract/smart-contract.service.test.ts
+++ b/src/modules/smart-contract/smart-contract.service.test.ts
@@ -91,6 +91,13 @@ describe('SmartContractService', () => {
             }),
           };
         }),
+        alterVoucher: jest.fn().mockImplementation(() => {
+          return {
+            call: jest.fn().mockResolvedValue({
+              transactionHash: '0x123',
+            }),
+          };
+        }),
       },
     }));
 
@@ -298,6 +305,46 @@ describe('SmartContractService', () => {
       const logErrorSpy = jest.spyOn(helpers, 'logError');
 
       await smartContractService.transferVoucher('0x123', '0x456');
+
+      expect(logErrorSpy).toHaveBeenCalledWith(
+        'Error in getVoucher: Error: Contract Error',
+      );
+
+      logErrorSpy.mockRestore();
+    });
+  });
+
+  describe('alterVoucher', () => {
+    it('should alter a voucher', async () => {
+      const result = await smartContractService.alterVoucher('0x123', '0x456');
+
+      expect(mockWeb3.eth.accounts.wallet.add).toBeCalledTimes(1);
+      expect(mockWeb3.eth.Contract).toBeCalledTimes(1);
+
+      expect(result).toEqual({
+        transactionHash: '0x123',
+      });
+    });
+
+    it('should throw an error if the contract method throws an error', async () => {
+      mockWeb3.eth.Contract = jest.fn().mockImplementation(() => {
+        return {
+          methods: {
+            alterVoucher: jest.fn().mockReturnValue({
+              call: jest.fn().mockRejectedValue(new Error('Contract Error')),
+            }),
+          },
+        };
+      });
+
+      smartContractService = new SmartContractService(
+        mockAppConfigService,
+        mockWeb3,
+      );
+
+      const logErrorSpy = jest.spyOn(helpers, 'logError');
+
+      await smartContractService.alterVoucher('0x123', '0x456');
 
       expect(logErrorSpy).toHaveBeenCalledWith(
         'Error in getVoucher: Error: Contract Error',

--- a/src/modules/smart-contract/smart-contract.service.test.ts
+++ b/src/modules/smart-contract/smart-contract.service.test.ts
@@ -36,6 +36,9 @@ describe('SmartContractService', () => {
 
   let smartContractService: SmartContractService;
 
+  // Constants
+  const gasFees = { gasPrice: 1, safeLow: 1, standard: 1, fast: 1 };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -105,11 +108,14 @@ describe('SmartContractService', () => {
       mockAppConfigService,
       mockWeb3,
     );
+
+    // This is to silence the console.error output from the logError helper
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    jest.spyOn(helpers, 'logError').mockImplementation(() => {});
   });
 
   describe('getGasFees', () => {
     it('should return gas fees', async () => {
-      const gasFees = { gasPrice: 1, safeLow: 1, standard: 1, fast: 1 };
       jest.spyOn(global, 'fetch').mockImplementation(
         () =>
           Promise.resolve({
@@ -130,7 +136,10 @@ describe('SmartContractService', () => {
     };
 
     it('should mint a voucher', async () => {
-      const gasFees = { gasPrice: 1, safeLow: 1, standard: 1, fast: 1 };
+      // Silence the console output from the logInfo helper
+      const logInfoSpy = jest.spyOn(helpers, 'logInfo');
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      logInfoSpy.mockImplementation(() => {});
 
       smartContractService.getGasFees = jest.fn().mockResolvedValue(gasFees);
 
@@ -140,6 +149,8 @@ describe('SmartContractService', () => {
       expect(response).toEqual({
         transactionHash: '0x123',
       });
+
+      logInfoSpy.mockRestore();
     });
 
     it('should throw an error if the contract method throws an error', async () => {

--- a/src/modules/smart-contract/smart-contract.service.ts
+++ b/src/modules/smart-contract/smart-contract.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { AppConfigService } from 'src/config/app-config.service';
-import { logError, logInfo } from 'src/helpers/common.helper';
+import { AppConfigService } from '../../config/app-config.service';
+import { logError, logInfo } from '../../helpers/common.helper';
 import Web3 from 'web3';
 import { Account, AddedAccount } from 'web3-core';
 import { Contract } from 'web3-eth-contract';

--- a/src/modules/smart-contract/transaction.service.test.ts
+++ b/src/modules/smart-contract/transaction.service.test.ts
@@ -14,8 +14,8 @@ describe('TransactionService', () => {
   // Mock entities
   const mockTransaction1: Transaction = {
     id: 'id',
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    createdAt: new Date('2023-06-20T10:00:00Z'),
+    updatedAt: new Date('2023-06-20T10:01:00Z'),
     senderId: '216fefae-c968-4f2a-b5a3-40eb621e2e71',
     ownerId: '7a11095d-ec42-4f9a-9fb1-3261b047c524',
     senderAmount: 1,
@@ -33,8 +33,8 @@ describe('TransactionService', () => {
 
   const mockTransaction2: Transaction = {
     id: 'id',
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    createdAt: new Date('2023-06-19T10:00:00Z'),
+    updatedAt: new Date('2023-06-19T10:01:00Z'),
     senderId: 'e4c30d3f-4c89-4a65-b83c-5db9821e6a81',
     ownerId: '9b48d780-74b5-4e26-89f9-eb89f4d3b0e7',
     senderAmount: 1,
@@ -50,12 +50,15 @@ describe('TransactionService', () => {
     voucher: { voucher: 'voucher2' },
   };
 
+  // Mock repositories
+  let mockTransactionRepository: Repository<Transaction>;
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
     // Mock repositories
-    const mockTransactionRepository = {
-      find: jest.fn(),
+    mockTransactionRepository = {
+      find: jest.fn().mockResolvedValue([mockTransaction1, mockTransaction2]),
       createQueryBuilder: jest.fn().mockReturnValue({
         leftJoinAndMapOne: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
@@ -72,5 +75,14 @@ describe('TransactionService', () => {
       mockAppConfigService,
       mockTransactionRepository,
     );
+  });
+
+  describe('getAllTransactionHistory', () => {
+    it('should return all transaction history', async () => {
+      const result = await service.getAllTransactionHistory();
+
+      expect(mockTransactionRepository.find).toHaveBeenCalled();
+      expect(result).toEqual([mockTransaction1, mockTransaction2]);
+    });
   });
 });

--- a/src/modules/smart-contract/transaction.service.test.ts
+++ b/src/modules/smart-contract/transaction.service.test.ts
@@ -64,9 +64,7 @@ describe('TransactionService', () => {
         select: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
-        getMany: jest
-          .fn()
-          .mockResolvedValue([mockTransaction1, mockTransaction2]),
+        getMany: jest.fn().mockResolvedValue([mockTransaction1]),
       }),
     } as unknown as Repository<Transaction>;
 
@@ -83,6 +81,45 @@ describe('TransactionService', () => {
 
       expect(mockTransactionRepository.find).toHaveBeenCalled();
       expect(result).toEqual([mockTransaction1, mockTransaction2]);
+    });
+
+    it('should return null if no transaction history found', async () => {
+      jest.spyOn(mockTransactionRepository, 'find').mockResolvedValueOnce(null);
+
+      const result = await service.getAllTransactionHistory();
+
+      expect(mockTransactionRepository.find).toHaveBeenCalled();
+      expect(result).toEqual(null);
+    });
+  });
+
+  describe('getTransactionHistoryBySenderId', () => {
+    it('should return transaction history by sender id', async () => {
+      const result = await service.getTransactionHistoryBySenderId(
+        '216fefae-c968-4f2a-b5a3-40eb621e2e71',
+      );
+
+      expect(mockTransactionRepository.createQueryBuilder).toHaveBeenCalled();
+      expect(result).toEqual([mockTransaction1]);
+    });
+
+    it('should return null if no transaction history found', async () => {
+      jest
+        .spyOn(mockTransactionRepository, 'createQueryBuilder')
+        .mockReturnValueOnce({
+          leftJoinAndMapOne: jest.fn().mockReturnThis(),
+          select: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          orderBy: jest.fn().mockReturnThis(),
+          getMany: jest.fn().mockResolvedValue(null),
+        } as any);
+
+      const result = await service.getTransactionHistoryBySenderId(
+        'someSenderId',
+      );
+
+      expect(mockTransactionRepository.createQueryBuilder).toHaveBeenCalled();
+      expect(result).toEqual(null);
     });
   });
 });

--- a/src/modules/smart-contract/transaction.service.test.ts
+++ b/src/modules/smart-contract/transaction.service.test.ts
@@ -1,0 +1,76 @@
+import { TransactionService } from './transaction.service';
+import { AppConfigService } from 'src/config/app-config.service';
+import { Transaction } from './entities/transaction.entity';
+import { Repository } from 'typeorm';
+import { UserType, VoucherStatus } from '../../common/constants/enums';
+
+describe('TransactionService', () => {
+  // Mock transaction service
+  let service: TransactionService;
+
+  // Mock services
+  const mockAppConfigService = {} as unknown as AppConfigService;
+
+  // Mock entities
+  const mockTransaction1: Transaction = {
+    id: 'id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    senderId: '216fefae-c968-4f2a-b5a3-40eb621e2e71',
+    ownerId: '7a11095d-ec42-4f9a-9fb1-3261b047c524',
+    senderAmount: 1,
+    senderCurrency: 'USD',
+    amount: 1,
+    conversionRate: 1,
+    currency: 'FC',
+    ownerType: UserType.PATIENT,
+    status: VoucherStatus.UNCLAIMED,
+    transactionHash: 'transactionHash1',
+    shortenHash: 'shortenHash1',
+    stripePaymentId: 'stripePaymentId1',
+    voucher: { voucher: 'voucher1' },
+  };
+
+  const mockTransaction2: Transaction = {
+    id: 'id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    senderId: 'e4c30d3f-4c89-4a65-b83c-5db9821e6a81',
+    ownerId: '9b48d780-74b5-4e26-89f9-eb89f4d3b0e7',
+    senderAmount: 1,
+    senderCurrency: 'USD',
+    amount: 1,
+    conversionRate: 1,
+    currency: 'FC',
+    ownerType: UserType.PATIENT,
+    status: VoucherStatus.UNCLAIMED,
+    transactionHash: 'transactionHash2',
+    shortenHash: 'shortenHash2',
+    stripePaymentId: 'stripePaymentId2',
+    voucher: { voucher: 'voucher2' },
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    // Mock repositories
+    const mockTransactionRepository = {
+      find: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        leftJoinAndMapOne: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest
+          .fn()
+          .mockResolvedValue([mockTransaction1, mockTransaction2]),
+      }),
+    } as unknown as Repository<Transaction>;
+
+    // Initialize mock transaction service
+    service = new TransactionService(
+      mockAppConfigService,
+      mockTransactionRepository,
+    );
+  });
+});

--- a/src/modules/smart-contract/transaction.service.ts
+++ b/src/modules/smart-contract/transaction.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { AppConfigService } from 'src/config/app-config.service';
+import { AppConfigService } from '../../config/app-config.service';
 import { Repository } from 'typeorm';
 import { Patient } from '../patient-svc/entities/patient.entity';
 import { Payer } from '../payer-svc/entities/payer.entity';


### PR DESCRIPTION
## Creation of New Test Suite for `smart-contract.service.ts` and `transaction.service.ts`

This pull request introduces a brand new test suite for the `SmartContractService`, which contains functionality to silence the log helper output for more readable tests. Additionally, it also introduces a new test suite for the accompanying `TransactionService`. This PR also contributes towards Issue #50, improving test coverage by ~5%. Here are the main features:

### Test Suite Introduction

An entirely new test suite has been created for `SmartContractService`. This test suite includes comprehensive test coverage for the following methods:

1. **getGasFees**

2. **mintVoucher**

3. **getVoucherById**

4. **getAllVouchers**

5. **transferVoucher**

6. **alterVoucher**

As well as a test suite for `TransactionService`, covering the following methods:

1. **getAllTransactionHistory**

2. **getTransactionHistoryBySenderId**

### Log Helper Output Silencing

To improve test readability, this PR also includes changes to silence the log helper output when running the test suite for `SmartContractService` contained in `smart-contract.service.test.ts`.

In the test suite, the `console.error` output from the `logError` helper and `console.log` output from the `logInfo` helper is silenced. This is done using jest's `spyOn` function to mock empty implementations of `logError` and `logInfo`. Note that this causes error output from the methods to be silenced, which could make debugging failing assertions more difficult. It may be worth refactoring the error messages in `smart-contract.service.test.ts` to align with the rest of the codebase and avoid this issue.

Review and feedback is much appreciated!