### PR TITLE
[Draft] Create test suite for payer-svc controller

### DIFF
--- a/src/modules/payer-svc/dto/payer.dto.ts
+++ b/src/modules/payer-svc/dto/payer.dto.ts
@@ -10,7 +10,7 @@ import {
   IsUUID,
   Length,
 } from 'class-validator';
-import { InviteType } from 'src/common/constants/enums';
+import { InviteType } from '../../../common/constants/enums';
 
 export class CreatePayerAccountDto {
   @IsNotEmpty()

--- a/src/modules/payer-svc/payer-svc.controller.test.ts
+++ b/src/modules/payer-svc/payer-svc.controller.test.ts
@@ -1,0 +1,50 @@
+import { Repository } from 'typeorm';
+import { PayerSvcController } from './payer-svc.controller';
+import { User } from '../session/entities/user.entity';
+import { PayerService } from './payer.service';
+import { CachingService } from '../caching/caching.service';
+import { SessionService } from '../session/session.service';
+import { PatientSvcService } from '../patient-svc/patient-svc.service';
+import { PatientResponseDto } from '../patient-svc/dto/patient.dto';
+
+describe('PayerSvcController', () => {
+  let mockUserRepository: Partial<Repository<User>>;
+  let mockPayerService: Partial<PayerService>;
+  let mockCachingService: Partial<CachingService>;
+  let mockSessionService: Partial<SessionService>;
+  let mockPatientService: Partial<PatientSvcService>;
+
+  beforeEach(async () => {
+    jest.clearAllMocks;
+
+    // Mock dependencies
+    mockUserRepository = {};
+
+    mockPayerService = {};
+
+    mockCachingService = {};
+
+    mockSessionService = {};
+
+    mockPatientService = {};
+
+    // Create controller
+    const payerSvcController = new PayerSvcController(
+      mockUserRepository as Repository<User>,
+      mockPayerService as PayerService,
+      mockCachingService as CachingService,
+      mockSessionService as SessionService,
+      mockPatientService as PatientSvcService,
+    );
+  });
+
+  describe('retrievePatientByPhoneNumber', () => {});
+
+  describe('retrievePayerAccountInfo', () => {});
+
+  describe('createPayerAccount', () => {});
+
+  describe('registerNewPatient', () => {});
+
+  describe('sendInviteToFriend', () => {});
+});

--- a/src/modules/payer-svc/payer-svc.controller.test.ts
+++ b/src/modules/payer-svc/payer-svc.controller.test.ts
@@ -1,12 +1,16 @@
 import { Repository } from 'typeorm';
 import { PayerSvcController } from './payer-svc.controller';
 import { User } from '../session/entities/user.entity';
+import { Payer } from '../payer-svc/entities/payer.entity';
 import { PayerService } from './payer.service';
 import { CachingService } from '../caching/caching.service';
 import { SessionService } from '../session/session.service';
 import { PatientSvcService } from '../patient-svc/patient-svc.service';
 import { SearchPatientDto } from './dto/payer.dto';
 import { PatientResponseDto } from '../patient-svc/dto/patient.dto';
+import { UserRole, UserStatus } from '../../common/constants/enums';
+import { NotFoundException } from '@nestjs/common';
+import { _404 } from '../../common/constants/errors';
 
 describe('PayerSvcController', () => {
   let mockUserRepository: Partial<Repository<User>>;
@@ -24,13 +28,43 @@ describe('PayerSvcController', () => {
     email: 'email',
   };
 
+  const mockUUID = '66a3b552-5b0b-428d-bd4e-d9f2d8182ba3';
+
+  const mockUser: User = {
+    id: 'id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    email: 'email',
+    phoneNumber: 'phoneNumber',
+    username: 'username',
+    role: UserRole.PAYER,
+    status: UserStatus.ACTIVE,
+    password: 'password',
+  };
+
+  const mockPayer: Payer = {
+    id: 'id',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    firstName: 'Jane',
+    lastName: 'Doe',
+    user: mockUser,
+    country: 'country',
+    homeAddress: 'homeAddress',
+    province: 'province',
+    city: 'city',
+    referralCode: 'referralCode',
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks;
 
     // Mock dependencies
     mockUserRepository = {};
 
-    mockPayerService = {};
+    mockPayerService = {
+      findPayerById: jest.fn().mockResolvedValue(mockPayer),
+    };
 
     mockCachingService = {};
 
@@ -61,7 +95,7 @@ describe('PayerSvcController', () => {
   describe('retrievePatientByPhoneNumber', () => {
     const mockSearchPatientDto: SearchPatientDto = {
       phoneNumber: 'phoneNumber',
-      payerId: 'payerId',
+      payerId: mockUUID,
     };
 
     it('should retrieve a patient by phone number', async () => {
@@ -100,7 +134,26 @@ describe('PayerSvcController', () => {
     });
   });
 
-  describe('retrievePayerAccountInfo', () => {});
+  describe('retrievePayerAccountInfo', () => {
+    it('should retrieve the payer by id', async () => {
+      // Call method
+      const response = await payerSvcController.retrievePayerAccountInfo(
+        mockUUID,
+      );
+
+      expect(mockPayerService.findPayerById).toHaveBeenCalledWith(mockUUID);
+      expect(response).toEqual(mockPayer);
+    });
+
+    it('should throw an error if payer is not found', async () => {
+      mockPayerService.findPayerById = jest.fn().mockResolvedValue(null);
+
+      // Call method
+      expect(async () =>
+        payerSvcController.retrievePayerAccountInfo(mockUUID),
+      ).rejects.toThrow(new NotFoundException(_404.PAYER_NOT_FOUND));
+    });
+  });
 
   describe('createPayerAccount', () => {});
 

--- a/src/modules/payer-svc/payer-svc.controller.ts
+++ b/src/modules/payer-svc/payer-svc.controller.ts
@@ -13,10 +13,10 @@ import {
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { InjectRepository } from '@nestjs/typeorm';
 import { isEmpty } from 'class-validator';
-import { UserRole } from 'src/common/constants/enums';
-import { AuthUser } from 'src/common/decorators/auth-user.decorator';
-import { Public } from 'src/common/decorators/public.decorator';
-import { Roles } from 'src/common/decorators/user-role.decorator';
+import { UserRole } from '../../common/constants/enums';
+import { AuthUser } from '../../common/decorators/auth-user.decorator';
+import { Public } from '../../common/decorators/public.decorator';
+import { Roles } from '../../common/decorators/user-role.decorator';
 import { Repository } from 'typeorm';
 import { _403, _404, _409 } from '../../common/constants/errors';
 import { CachingService } from '../caching/caching.service';

--- a/src/modules/session/dto/jwt-claims-data.dto.ts
+++ b/src/modules/session/dto/jwt-claims-data.dto.ts
@@ -1,5 +1,5 @@
 import { IsEnum, IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
-import { UserRole, UserStatus } from 'src/common/constants/enums';
+import { UserRole, UserStatus } from '../../../common/constants/enums';
 
 export class JwtClaimsDataDto {
   @IsUUID()


### PR DESCRIPTION
# PR Summary 

This PR contains a new test suite `payer-svc.controller.test.ts` that tests all methods of `payer-svc.controller.ts`, including:

1. `retrievePatientByPhoneNumber`
2. `retrievePayerAccountInfo`
3. `createPayerAccount`
4. `registerNewPatient`
5. `sendInviteToFriend`
6.  `sendSmsVoucher`

This will further progress towards closing Issue #50.